### PR TITLE
Fix build regression and optional devPort not being used

### DIFF
--- a/app_server.tsx
+++ b/app_server.tsx
@@ -57,7 +57,9 @@ function html<
       };
     </script>`,
     isDevelopment() && devPort
-      ? `<script>window.app.devPort = ${serialize(devPort, { isJSON: true })};</script>`
+      ? `<script>window.app.devPort = ${
+        serialize(devPort, { isJSON: true })
+      };</script>`
       : null,
     isDevelopment() && `<script type="module" src="/live-reload.js"></script>`,
     helmet.noscript.toString(),
@@ -280,7 +282,11 @@ export function createApp<
  * This function will not do anything if the app is not running in development mode.
  */
 export async function listeningDev(
-  { hostname, secure, devPort }: { hostname: string; secure: boolean, devPort?: number },
+  { hostname, secure, devPort }: {
+    hostname: string;
+    secure: boolean;
+    devPort?: number;
+  },
 ) {
   if (isDevelopment()) {
     try {
@@ -310,7 +316,9 @@ export async function serve<
   app.addEventListener("listen", ({ hostname, port, secure }) => {
     const origin = `${secure ? "https://" : "http://"}${hostname}`;
     console.log(`Listening on: ${origin}:${port}`);
-    queueMicrotask(() => listeningDev({ hostname, secure, devPort: options.devPort }));
+    queueMicrotask(() =>
+      listeningDev({ hostname, secure, devPort: options.devPort })
+    );
   });
 
   const listenOptions = {} as ListenOptions;

--- a/app_server.tsx
+++ b/app_server.tsx
@@ -34,12 +34,13 @@ export interface HTMLOptions<
   helmet: HelmetContext.HelmetServerState;
   env: AppEnvironment;
   context: AppContext;
+  devPort?: number;
 }
 
 function html<
   AppContext extends Record<string, unknown> = Record<string, unknown>,
 >(
-  { helmet, env, context }: HTMLOptions<AppContext>,
+  { helmet, env, context, devPort }: HTMLOptions<AppContext>,
 ) {
   const headTags = [
     helmet.base.toString(),
@@ -55,6 +56,9 @@ function html<
         context: ${serialize(context, { isJSON: true })},
       };
     </script>`,
+    isDevelopment() && devPort
+      ? `<script>window.app.devPort = ${serialize(devPort, { isJSON: true })};</script>`
+      : null,
     isDevelopment() && `<script type="module" src="/live-reload.js"></script>`,
     helmet.noscript.toString(),
   ].filter((tag: string) => Boolean(tag));
@@ -84,7 +88,7 @@ export async function renderToReadableStream<
 ) {
   const { request, state } = context;
   const { route, Provider } = state._app;
-  const { env, context: appContext } = state.app;
+  const { env, context: appContext, devPort } = state.app;
   const { pathname, search } = request.url;
   const location = `${pathname}${search}`;
   const helmetContext = {} as HelmetContext;
@@ -115,6 +119,7 @@ export async function renderToReadableStream<
     helmet: helmetContext.helmet,
     env,
     context: appContext,
+    devPort,
   });
 
   return stream
@@ -275,12 +280,12 @@ export function createApp<
  * This function will not do anything if the app is not running in development mode.
  */
 export async function listeningDev(
-  { hostname, secure }: { hostname: string; secure: boolean },
+  { hostname, secure, devPort }: { hostname: string; secure: boolean, devPort?: number },
 ) {
   if (isDevelopment()) {
     try {
       const origin = `${secure ? "https://" : "http://"}${hostname}`;
-      await fetch(`${origin}:9002/listening`);
+      await fetch(`${origin}:${devPort || 9002}/listening`);
     } catch {
       // Ignore errors
     }
@@ -305,7 +310,7 @@ export async function serve<
   app.addEventListener("listen", ({ hostname, port, secure }) => {
     const origin = `${secure ? "https://" : "http://"}${hostname}`;
     console.log(`Listening on: ${origin}:${port}`);
-    queueMicrotask(() => listeningDev({ hostname, secure }));
+    queueMicrotask(() => listeningDev({ hostname, secure, devPort: options.devPort }));
   });
 
   const listenOptions = {} as ListenOptions;

--- a/build.ts
+++ b/build.ts
@@ -71,7 +71,7 @@ async function buildRoutes(moduleUrl: string) {
     return route;
   }
 
-  const routesUrl = path.resolve(moduleUrl, "./routes");
+  const routesUrl = path.join(moduleUrl, "./routes");
   for await (const entry of walk(routesUrl)) {
     if (!entry.isFile) continue;
     const routeFileName = entry.name.match(ROUTE_FILE_NAME);
@@ -113,10 +113,10 @@ async function buildRoutes(moduleUrl: string) {
       const routePath = routePathFromName(route.name.slice(0, -4));
       const routerFileName = route.name.slice(0, -4);
       if (
-        await exists(path.resolve(routesUrl, directory, `${routerFileName}.ts`))
+        await exists(path.join(routesUrl, directory, `${routerFileName}.ts`))
       ) {
         routerFileImports += `import $${routeId} from "./${
-          path.posix.join("./routes", posixDirectory, routerFileName)
+          path.posix.join("./routes", posixDirectory, `${routerFileName}.ts`)
         }";\n`;
         routerFileExports += `const router${routeId} = new Router();\n`;
         routerFileExports +=
@@ -127,7 +127,7 @@ async function buildRoutes(moduleUrl: string) {
             `router${parentRouteId}.use("/${routerPath}", router${routeId}.routes(), router${routeId}.allowedMethods());\n`;
         }
       } else if (
-        await exists(path.resolve(routesUrl, directory, `${routerFileName}.js`))
+        await exists(path.join(routesUrl, directory, `${routerFileName}.js`))
       ) {
         routerFileImports += `import $${routeId} from "./${
           path.posix.join("./routes", posixDirectory, `${routerFileName}.js`)
@@ -161,13 +161,13 @@ async function buildRoutes(moduleUrl: string) {
 
       const mainRouteId = routeId;
       routerFileExports += `const router${mainRouteId} = new Router();\n`;
-      if (await exists(path.resolve(routesUrl, directory, "main.ts"))) {
+      if (await exists(path.join(routesUrl, directory, "main.ts"))) {
         routerFileImports += `import $${mainRouteId} from "./${
           path.posix.join("./routes", posixDirectory, "main.ts")
         }";\n`;
         routerFileExports +=
           `addMiddleware(router${mainRouteId}, ...$${mainRouteId});\n`;
-      } else if (await exists(path.resolve(routesUrl, directory, "main.js"))) {
+      } else if (await exists(path.join(routesUrl, directory, "main.js"))) {
         routerFileImports += `import $${mainRouteId} from "./${
           path.posix.join("./routes", posixDirectory, "main.js")
         }";\n`;
@@ -182,14 +182,14 @@ async function buildRoutes(moduleUrl: string) {
           path.posix.join("./routes", posixDirectory, route.index)
         }";\n`;
         routerFileExports += `const router${routeId} = new Router();\n`;
-        if (await exists(path.resolve(routesUrl, directory, "index.ts"))) {
+        if (await exists(path.join(routesUrl, directory, "index.ts"))) {
           routerFileImports += `import $${routeId} from "./${
             path.posix.join("./routes", posixDirectory, "index.ts")
           };\n`;
           routerFileExports +=
             `addMiddleware(router${routeId}, ...$${routeId});\n`;
         } else if (
-          await exists(path.resolve(routesUrl, directory, "index.js"))
+          await exists(path.join(routesUrl, directory, "index.js"))
         ) {
           routerFileImports += `import $${routeId} from "./${
             path.posix.join("./routes", posixDirectory, "index.js")
@@ -304,7 +304,7 @@ export interface BuildOptions {
 export async function build(options: BuildOptions) {
   const { moduleUrl } = options;
   const entryPoint = "app.tsx";
-  const outdir = path.resolve(
+  const outdir = path.join(
     moduleUrl,
     "public",
     `${isTest() ? "test-" : ""}build`,
@@ -312,7 +312,7 @@ export async function build(options: BuildOptions) {
   await ensureDir(outdir);
 
   const importMapURL = path.toFileUrl(
-    path.resolve(moduleUrl, "import_map.json"),
+    path.join(moduleUrl, "import_map.json"),
   );
 
   const buildOptions: esbuild.BuildOptions = isProduction() ? {} : {

--- a/dev.ts
+++ b/dev.ts
@@ -2,7 +2,7 @@ import * as path from "$std/path/mod.ts";
 import { debounce } from "$std/async/debounce.ts";
 import { Application, Router } from "$x/oak/mod.ts";
 import { HttpError } from "$x/http_error/mod.ts";
-import { isTest } from "./env.ts";
+import { getEnv, isTest } from "./env.ts";
 
 const sessions = new Map<number, WebSocket>();
 let nextSessionId = 0;
@@ -214,5 +214,10 @@ export function startDev({
 }
 
 if (import.meta.main) {
-  startDev();
+  const options: DevOptions = {}
+  const devPort = + (getEnv("DEV_PORT") ?? "");
+  if (devPort && !isNaN(devPort)) {
+    options.devPort = devPort;
+  }
+  startDev(options);
 }

--- a/dev.ts
+++ b/dev.ts
@@ -214,8 +214,8 @@ export function startDev({
 }
 
 if (import.meta.main) {
-  const options: DevOptions = {}
-  const devPort = + (getEnv("DEV_PORT") ?? "");
+  const options: DevOptions = {};
+  const devPort = +(getEnv("DEV_PORT") ?? "");
   if (devPort && !isNaN(devPort)) {
     options.devPort = devPort;
   }


### PR DESCRIPTION
In the build, I switched from path.join to path.resolve in my last PR. This caused the urls to resolve differently resulting in it not finding files that exist. I believe the initial reason I did so was because I thought it was needed for the windows build to pass but I think join will work on windows too. If it doesn't, this PR will fail to pass CI.

To be able to set a custom devPort. All you have to do is update your dev task to have `export DEV_PORT=1234` and add the devPort argument with the same port to serve in your main.ts file. Replace 1234 with desired port for live reload server from the dev script to listen on.