### PR TITLE
Use SSE instead of WebSocket for live reload

### DIFF
--- a/app_server.tsx
+++ b/app_server.tsx
@@ -64,7 +64,7 @@ function html<
     `<script>window.app.devPort = ${
       serialize(devPort, { isJSON: true })
     };</script>`,
-    isDevelopment() && `<script type="module" src="/live-reload.js"></script>`,
+    isDevelopment() && `<script src="/live-reload.js"></script>`,
     helmet.noscript.toString(),
   ].filter((tag: string) => Boolean(tag));
 

--- a/live-reload.js
+++ b/live-reload.js
@@ -1,19 +1,18 @@
 const devPort = window.app.devPort ?? 9002;
-const ws = new WebSocket(`ws://localhost:${devPort}/live-reload`);
-ws.onopen = () => {
+console.log(`http://localhost:${devPort}/live-reload`);
+const source = new EventSource(`http://localhost:${devPort}/live-reload`);
+source.addEventListener("open", () => {
   console.log("Live reload: Waiting for change");
-};
-ws.onclose = () => {
+});
+source.addEventListener("close", () => {
   console.log("Live reload: Stopped");
-};
-ws.onmessage = (message) => {
-  const data = JSON.parse(message.data);
-  const { command } = data;
-  if (command === "reload") {
-    console.log("Live reload: Reloading");
-    location.reload();
-  }
-};
-ws.onerror = (event) => {
+});
+source.addEventListener("error", (event) => {
   console.log("Live reload: Error", event);
-};
+});
+source.addEventListener("reload", () => {
+  console.log("Live reload: Reloading");
+  location.reload();
+});
+
+globalThis.addEventListener("beforeunload", () => source.close());

--- a/live-reload.js
+++ b/live-reload.js
@@ -1,5 +1,4 @@
 const devPort = window.app.devPort ?? 9002;
-console.log(`http://localhost:${devPort}/live-reload`);
 const source = new EventSource(`http://localhost:${devPort}/live-reload`);
 source.addEventListener("open", () => {
   console.log("Live reload: Waiting for change");


### PR DESCRIPTION
An EventSource is better than a WebSocket in this use case since communication goes one way from the server to the client. Chrome will also automatically reconnect to the dev server if you restart the dev script. There is a bug in Firefox that causes auto-reconnect to not work, but live reload will still work in Firefox though.