### PR TITLE
Move release from main.yml to release.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,5 @@
 name: CI/CD
 on:
-  create:
   pull_request:
   push:
     branches:
@@ -21,8 +20,3 @@ jobs:
     with:
       project: udibo-react-app
       app-directory: ./example
-  release:
-    name: Release
-    needs: ci
-    uses: ./.github/workflows/release.yml
-    if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 on:
+  create:
+  push:
+    branches:
+      - main
   workflow_call:
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.1.1-success)](https://github.com/udibo/react_app/releases/tag/0.1.1)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.1.1)
+[![release](https://img.shields.io/badge/release-0.1.2-success)](https://github.com/udibo/react_app/releases/tag/0.1.2)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.1.2)
 [![CI](https://github.com/udibo/react_app/workflows/CI/badge.svg)](https://github.com/udibo/react_app/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [app.tsx](https://deno.land/x/udibo_react_app@0.1.1/app.tsx): For use in code
+- [app.tsx](https://deno.land/x/udibo_react_app@0.1.2/app.tsx): For use in code
   that will be used both in the browser and on the server.
-- [app_server.tsx](https://deno.land/x/udibo_react_app@0.1.1/app_server.tsx):
+- [app_server.tsx](https://deno.land/x/udibo_react_app@0.1.2/app_server.tsx):
   For use in code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.1.1) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.1.2) to learn more about
 usage.
 
 ### Examples


### PR DESCRIPTION
Deploy step won't work on tag creation. This makes it so that CI/CD won't run on tag creation and instead only the release action will run on tag creation.