### PR TITLE
Fix App and Hydrate option types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.3.0-success)](https://github.com/udibo/react_app/releases/tag/0.3.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.3.0)
+[![release](https://img.shields.io/badge/release-0.3.1-success)](https://github.com/udibo/react_app/releases/tag/0.3.1)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.3.1)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.3.0/mod.tsx): For use in code
-  that will be used both in the browser and on the server.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.3.0/server.tsx): For use in
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.3.1/mod.tsx): For use in code
+  that will be used both on the server and in the browser.
+- [server.tsx](https://deno.land/x/udibo_react_app@0.3.1/server.tsx): For use in
   code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.3.0) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.3.1) to learn more about
 usage.
 
 ### Examples

--- a/mod.tsx
+++ b/mod.tsx
@@ -55,7 +55,7 @@ export interface HydrateOptions<
   /** Adds your own providers around the application. */
   Provider?: ComponentType<{ children: ReactNode }>;
   /** A context object for the App. */
-  Context: Context<AppContext>;
+  Context?: Context<AppContext>;
 }
 
 interface AppOptions<
@@ -65,10 +65,12 @@ interface AppOptions<
   Context: Context<AppContext>;
 }
 
-function App({ route, Provider, Context }: AppOptions) {
+function App<
+  AppContext extends Record<string, unknown> = Record<string, unknown>,
+>({ route, Provider, Context }: AppOptions<AppContext>) {
   const router = createBrowserRouter([route]);
   const errorJSON = (window as AppWindow).app.error;
-  const context = (window as AppWindow).app.context ?? {};
+  const context = (window as AppWindow<AppContext>).app.context ?? {};
   const appErrorContext = { error: errorJSON && new HttpError(errorJSON) };
   return (
     <StrictMode>
@@ -104,7 +106,7 @@ function App({ route, Provider, Context }: AppOptions) {
  */
 export function hydrate<
   AppContext extends Record<string, unknown> = Record<string, unknown>,
->({ route, Provider, Context }: HydrateOptions) {
+>({ route, Provider, Context }: HydrateOptions<AppContext>) {
   const hydrate = () =>
     startTransition(() => {
       hydrateRoot(


### PR DESCRIPTION
Hydrate shouldn't have required a Context argument. This makes it optional and updates App to also take a generic AppContext.