### PR TITLE
Undo change to use deno task run in dev task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.3.2-success)](https://github.com/udibo/react_app/releases/tag/0.3.2)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.3.2)
+[![release](https://img.shields.io/badge/release-0.3.3-success)](https://github.com/udibo/react_app/releases/tag/0.3.3)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.3.3)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.3.2/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.3.3/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.3.2/server.tsx): For use in
+- [server.tsx](https://deno.land/x/udibo_react_app@0.3.3/server.tsx): For use in
   code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.3.2) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.3.3) to learn more about
 usage.
 
 ### Examples

--- a/example/deno.jsonc
+++ b/example/deno.jsonc
@@ -2,7 +2,7 @@
   "tasks": {
     "build": "deno run -A ../build.ts",
     "run": "deno run -A ./main.ts",
-    "dev": "deno run -A --import-map=./import_map.json ../dev.ts",
+    "dev": "export APP_ENTRY_POINT=./main.ts && deno run -A --import-map=./import_map.json ../dev.ts",
     "test": "export APP_ENV=test && deno test -A .",
     "test-watch": "export APP_ENV=test && deno test -A --watch .",
     "check": "deno lint && deno fmt --check",


### PR DESCRIPTION
I thought it would be good to use `deno task run` in the dev script but found the reason why I wasn't originally.
When you kill a run task process, it could continue to keep running. This would cause the port to get taken up preventing the dev script from starting up the application server again.

This also makes the entry point for the application server configurable through the APP_ENTRY_POINT environment variable or through the startDev entryPoint option.