### PR TITLE
Add useAutoReset hook for error fallbacks to use and import main route statically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.3.3-success)](https://github.com/udibo/react_app/releases/tag/0.3.3)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.3.3)
+[![release](https://img.shields.io/badge/release-0.4.0-success)](https://github.com/udibo/react_app/releases/tag/0.4.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.4.0)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.3.3/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.4.0/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.3.3/server.tsx): For use in
+- [server.tsx](https://deno.land/x/udibo_react_app@0.4.0/server.tsx): For use in
   code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.3.3) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.4.0) to learn more about
 usage.
 
 ### Examples
@@ -58,13 +58,10 @@ how it was done.
 - [Twind Example](https://github.com/udibo/react_app_example_twind): A basic
   example of a [Udibo React App](https://deno.land/x/udibo_react_app) using
   [Twind](https://twind.style/) to add Tailwind v3 support.
-
-<!--
 - [React Query Example](https://github.com/udibo/react_app_example_react_query):
   A basic example of a [Udibo React App](https://deno.land/x/udibo_react_app)
   using [React Query](https://tanstack.com/query/latest) for asyncronous state
   management.
--->
 
 ### Tasks
 

--- a/example/routes/blog/[id].tsx
+++ b/example/routes/blog/[id].tsx
@@ -11,7 +11,7 @@ export default function BlogPost() {
   if (isNaN(id) || Math.floor(id) !== id || id < 0) {
     throw new HttpError(400, "Invalid id");
   }
-  const post = isServer() ? undefined : getPost(id);
+  const post = getPost(id);
   return post
     ? (
       <>


### PR DESCRIPTION
The useAutoReset hook makes it easier to create error fallbacks that will clear the error when the reset function is called or the user navigates away from the current route.

Importing the main route at the root of the routes statically reduces the number of requests. It shouldn't have been lazy loaded since it's used for all routes. This change also ensures a default error fallback is added to the root route if the user doesn't provide an error fallback in their main route.