### PR TITLE
Make server entrypoint configurable in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: './'
+      entrypoint:
+        required: false
+        type: string
+        default: 'main.ts'
       app-directory:
         required: false
         type: string
@@ -54,5 +58,5 @@ jobs:
         with:
           project: ${{ inputs.project }}
           root: ${{ inputs.working-directory }}
-          entrypoint: '${{ inputs.app-directory || inputs.working-directory }}/main.ts'
+          entrypoint: '${{ inputs.app-directory || inputs.working-directory }}/${{ inputs.entrypoint }}'
           import-map: '${{ inputs.app-directory || inputs.working-directory }}/import_map.json'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.4.0-success)](https://github.com/udibo/react_app/releases/tag/0.4.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.4.0)
+[![release](https://img.shields.io/badge/release-0.5.0-success)](https://github.com/udibo/react_app/releases/tag/0.5.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.5.0)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.4.0/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.5.0/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.4.0/server.tsx): For use in
+- [server.tsx](https://deno.land/x/udibo_react_app@0.5.0/server.tsx): For use in
   code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.4.0) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.5.0) to learn more about
 usage.
 
 ### Examples


### PR DESCRIPTION
The main entrypoint in my react query example uses tsx in the main entrypoint. Before I had it hardcoded to always use main.ts as the entrypoint. Now the deploy script allows you to specify any file as the entrypoint.