### PR TITLE
Remove default ErrorFallback and add boundary override

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,14 +191,16 @@ There are 2 ways to add error handling to your UI routes.
 
 The easiest way is to add an ErrorFallback export to your UI Route. The related
 API router will automatically have error boundary middleware added to it, that
-will match the route path. For example, the `/blog/[id]` route would have the
-error's boundary identifier set to `"/blog/[id]"`. Then the AppErrorBoundary
-added around your component will have a matching boundary identifier.
+will match the route path unless a different one is specified via a boundary
+export. For example, the `/blog/[id]` route would have the error's boundary
+identifier set to `"/blog/[id]"`. Then the AppErrorBoundary added around your
+component will have a matching boundary identifier.
 
 If you'd like to nest an error boundary within your UI route component, you can
 use AppErrorBoundary or withAppErrorBoundary. If you do it this way, you will
-need to add errorBoundary middleware to your router to ensure any errors in that
-route are associated with the AppErrorBoundary you added.
+need to either export a boundary string or manually add errorBoundary middleware
+to your router to ensure any errors in that route are associated with the
+AppErrorBoundary you added.
 
 ```ts
 const router = new Router()

--- a/mod.tsx
+++ b/mod.tsx
@@ -143,6 +143,8 @@ export type RouteFile = {
   default: ComponentType;
   /** An ErrorFallback for an AppErrorBoundary around the react component for the route. */
   ErrorFallback?: ComponentType<FallbackProps>;
+  /** The boundary used by the route. If there is an ErrorFallback exported, exporting a boundary will override the default boundary. */
+  boundary?: string;
 };
 
 /**
@@ -164,16 +166,18 @@ export function lazy<
   boundaryOrFactory?: string | (() => Promise<T>),
   factory?: () => Promise<T>,
 ): LazyExoticComponent<ComponentType> {
-  const boundary = typeof boundaryOrFactory === "string"
+  let boundary = typeof boundaryOrFactory === "string"
     ? boundaryOrFactory
     : undefined;
   if (typeof boundaryOrFactory !== "string") factory = boundaryOrFactory;
   return reactLazy(async () => {
-    const { default: Component, ErrorFallback } = await factory!();
+    const { default: Component, ErrorFallback, boundary: boundaryOverride } =
+      await factory!();
     const errorBoundaryProps = {
       FallbackComponent: ErrorFallback,
     } as AppErrorBoundaryProps;
-    if (boundary) errorBoundaryProps.boundary = boundary;
+    if (boundaryOverride) boundary = boundaryOverride;
+    if (boundary) errorBoundaryProps.boundary = boundaryOverride ?? boundary;
 
     return {
       default: errorBoundaryProps.FallbackComponent

--- a/server.tsx
+++ b/server.tsx
@@ -450,10 +450,16 @@ export const defaultRouter = new Router()
  * If a boundary is specified, but no AppErrorBoundary exists with a matching boundary, the error will go unhandled.
  *
  * By default, any route that has an ErrorFallback will have an errorBoundary automatically added to it.
- * The automatic error boundaries name will match the route.
+ * The automatic error boundaries name will match the route by default.
+ * If a route exports a boundary string, that will be used as the errorBoundary's boundary.
  * You can add your own error boundaries anywhere.
  *
- * To ensure an error boundary catches the error, your router needs to use this middleware.
+ * To ensure an error boundary catches the error, you need to either export a boundary string from your route
+ * or your router needs to use the error boundary middleware.
+ *
+ * ```ts
+ * export const boundary = "MyComponentErrorBoundary"
+ * ```
  *
  * ```ts
  * const router = new Router()


### PR DESCRIPTION
By default, if an ErrorFallback wasn't specified in the main route for your routes directory, it would add an error boundary with the DefaultErrorFallback as its ErrorFallback. This gets rid of that so that it's possible to define your own error boundary within your component without having to specify a boundary.

I believe it will be common for people to want to add their own AppErrorBoundary within the component for a route. To make this easier, I added the ability to export a boundary string from the file instead of an ErrorFallback component. If you export a boundary string, the server will use that for it's errorBoundary middleware, making it easier to signal that it should use the AppErrorBoundary within your route's component.