### PR TITLE
Add default not found route to sub-directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.6.0-success)](https://github.com/udibo/react_app/releases/tag/0.6.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.6.0)
+[![release](https://img.shields.io/badge/release-0.7.0-success)](https://github.com/udibo/react_app/releases/tag/0.7.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.7.0)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.6.0/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.7.0/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.6.0/server.tsx): For use in
+- [server.tsx](https://deno.land/x/udibo_react_app@0.7.0/server.tsx): For use in
   code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.6.0) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.7.0) to learn more about
 usage.
 
 ### Examples

--- a/example/deno.lock
+++ b/example/deno.lock
@@ -130,7 +130,6 @@
     "https://deno.land/std@0.177.0/types.d.ts": "220ed56662a0bd393ba5d124aa6ae2ad36a00d2fcbc0e8666a65f4606aaa9784",
     "https://deno.land/std@0.178.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
     "https://deno.land/std@0.178.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
-    "https://deno.land/std@0.178.0/async/debounce.ts": "adab11d04ca38d699444ac8a9d9856b4155e8dda2afd07ce78276c01ea5a4332",
     "https://deno.land/std@0.178.0/async/deferred.ts": "42790112f36a75a57db4a96d33974a936deb7b04d25c6084a9fa8a49f135def8",
     "https://deno.land/std@0.178.0/bytes/bytes_list.ts": "b4cbdfd2c263a13e8a904b12d082f6177ea97d9297274a4be134e989450dfa6a",
     "https://deno.land/std@0.178.0/bytes/concat.ts": "d26d6f3d7922e6d663dacfcd357563b7bf4a380ce5b9c2bbe0c8586662f25ce2",

--- a/example/routes/blog/[id].tsx
+++ b/example/routes/blog/[id].tsx
@@ -1,7 +1,6 @@
 import { useParams } from "npm/react-router-dom";
 import { HttpError } from "x/http_error/mod.ts";
 import { Helmet } from "npm/react-helmet-async";
-import { DefaultErrorFallback, isServer } from "x/udibo_react_app/mod.tsx";
 
 import { getPost } from "../../services/posts.tsx";
 
@@ -32,5 +31,3 @@ export default function BlogPost() {
       </>
     );
 }
-
-export const ErrorFallback = DefaultErrorFallback;

--- a/example/routes/blog/main.tsx
+++ b/example/routes/blog/main.tsx
@@ -1,6 +1,10 @@
 import { Suspense } from "npm/react";
 import { Outlet } from "npm/react-router-dom";
 import { Helmet } from "npm/react-helmet-async";
+import {
+  AppErrorBoundary,
+  DefaultErrorFallback,
+} from "x/udibo_react_app/mod.tsx";
 
 import { Loading } from "../../components/loading.tsx";
 
@@ -12,8 +16,15 @@ export default function Blog() {
       </Helmet>
       <h1>Blog</h1>
       <Suspense fallback={<Loading />}>
-        <Outlet />
+        <AppErrorBoundary
+          FallbackComponent={DefaultErrorFallback}
+          boundary="/blog"
+        >
+          <Outlet />
+        </AppErrorBoundary>
       </Suspense>
     </>
   );
 }
+
+export const boundary = "/blog";


### PR DESCRIPTION
If in a sub directory and a matching route isn't found, it would end up going back up to the parent route. Only the root directory for the routes had a default not found route that throws a not found error.

Now if a sub-directory doesn't have a not found route or parameter route, it will have the same default not found route added to it.

The default not found route will throw a not found error so that the app error boundary catches and handles it.

The update to the example was not needed for this PR. I just decided to include it. It makes it so the blog title will be shown above errors anywhere in the blog directory rather than just for the parameterized route.