### PR TITLE
Undo boundary change after file routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.8.0-success)](https://github.com/udibo/react_app/releases/tag/0.8.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.8.0)
+[![release](https://img.shields.io/badge/release-0.9.0-success)](https://github.com/udibo/react_app/releases/tag/0.9.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.9.0)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.8.0/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.9.0/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.8.0/server.tsx): For use in
+- [server.tsx](https://deno.land/x/udibo_react_app@0.9.0/server.tsx): For use in
   code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.8.0) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.9.0) to learn more about
 usage.
 
 ### Examples

--- a/build.ts
+++ b/build.ts
@@ -273,6 +273,7 @@ function routerFileData(
         `  $${parentRouteId}.use("/${
           routerPathFromName(name)
         }", errorBoundary(($${routeId} as RouteFile).boundary ?? "/${relativePath}"));`,
+        `  $${parentRouteId}.use(errorBoundary(boundaries[boundaries.length - 1]));`,
         `}`,
       );
       routeId++;
@@ -328,10 +329,10 @@ function routerFileData(
           `  const boundary = ($${routeId} as RouteFile).boundary${
             relativePath ? ` ?? "/${relativePath}"` : ""
           };`,
-          `  boundaries.push(boundary ?? "");`,
+          `  boundaries.push(boundary);`,
           `  $${mainRouteId}.use(errorBoundary(boundary));`,
           `} else {`,
-          `  boundaries.push(boundaries[boundaries.length - 1] ?? "");`,
+          `  boundaries.push(boundaries[boundaries.length - 1]);`,
           `}`,
         );
         routeId++;
@@ -488,7 +489,7 @@ async function updateRoutes(routesUrl: string, rootRoute: Route) {
     `import { defaultRouter, createApiRouter, errorBoundary } from "x/udibo_react_app/server.tsx";`,
     `import { RouteFile } from "x/udibo_react_app/mod.tsx";`,
     "",
-    "const boundaries: string[] = [];",
+    "const boundaries: (string | undefined)[] = [];",
   ];
   const { importLines, routerLines } = routerFileData(-1, 0, "", rootRoute);
   lines.push(...importLines, "", ...routerLines);


### PR DESCRIPTION
If a file route has a boundary, that boundary would incorrectly get used when trying to access a child route. For example, the blog route directory exists and it has an [id] parameter route file. With the following url, the error boundary from [id].tsx would be used if it had one.

http://localhost:9000/blog/2

However, if you tried accessing a sub route for that blog post, like the following url, it would still use the boundary from [id].tsx even though react router wouldn't use it. That would cause urls like this to not render on the server because a matching error boundary is not reached from the react code. We would then fallback to a suspense boundary instead.

http://localhost:9000/blog/2/comments

To resolve this issue, routers for files that do not handle the request will switch back to using the current directories boundary. For the above url, it would now use the "/blog" boundary instead of the "/blog/[id]" boundary since comments doesn't match any of the files or directories in the blog route.