### PR TITLE
Fix undefined being logged as error when client renders without error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.9.0-success)](https://github.com/udibo/react_app/releases/tag/0.9.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.9.0)
+[![release](https://img.shields.io/badge/release-0.9.1-success)](https://github.com/udibo/react_app/releases/tag/0.9.1)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.9.1)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.9.0/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.9.1/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.9.0/server.tsx): For use in
+- [server.tsx](https://deno.land/x/udibo_react_app@0.9.1/server.tsx): For use in
   code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.9.0) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.9.1) to learn more about
 usage.
 
 ### Examples

--- a/mod.tsx
+++ b/mod.tsx
@@ -85,10 +85,12 @@ function App<
   const rawError = (window as AppWindow).app.error;
   const { stack, ...errorOptions } = rawError ?? {};
   const error = rawError && new HttpError(errorOptions);
-  if (error && typeof stack === "string") {
-    error.stack = stack;
+  if (error) {
+    if (typeof stack === "string") {
+      error.stack = stack;
+    }
+    console.error(error);
   }
-  console.error(error);
 
   const context = (window as AppWindow<AppContext>).app.context ?? {};
   const appErrorContext = { error };


### PR DESCRIPTION
When the app renders without an error, it would incorrectly call `console.error(error)` still even though error is undefined. This updates it to check that error is defined before logging.