### PR TITLE
Move parameter routes and wildcard routes to the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.10.0-success)](https://github.com/udibo/react_app/releases/tag/0.10.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.10.0)
+[![release](https://img.shields.io/badge/release-0.11.0-success)](https://github.com/udibo/react_app/releases/tag/0.11.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.11.0)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.10.0/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.11.0/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.10.0/server.tsx): For use
+- [server.tsx](https://deno.land/x/udibo_react_app@0.11.0/server.tsx): For use
   in code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.10.0) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.11.0) to learn more about
 usage.
 
 ### Examples

--- a/server.tsx
+++ b/server.tsx
@@ -535,8 +535,8 @@ export interface RouterDefinition {
   children?: Record<string, RouterDefinition>;
 }
 
-const ROUTE_PARAM = /^\[(.+)]$/;
-const ROUTE_WILDCARD = /^\[\.\.\.\]$/;
+export const ROUTE_PARAM = /^\[(.+)]$/;
+export const ROUTE_WILDCARD = /^\[\.\.\.\]$/;
 export function routePathFromName(name: string, forServer = false) {
   if (!name) return "";
   return name


### PR DESCRIPTION
React Router automatically routes to the most specific route first, so for that it doesn't matter what the order is for the routes. Oak is not the same and the order of the routes matters. Before this fix, if you had both a parameterized route and a regular route, the parameterized route would catch requests to the regular route. This fixes it by moving the parameterized routes and regular routes to the end of the list of children for a router.