### PR TITLE
Make response empty for API not found errors with extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Udibo React App
 
-[![release](https://img.shields.io/badge/release-0.13.0-success)](https://github.com/udibo/react_app/releases/tag/0.13.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.13.0)
+[![release](https://img.shields.io/badge/release-0.14.0-success)](https://github.com/udibo/react_app/releases/tag/0.14.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://deno.land/x/udibo_react_app@0.14.0)
 [![CI/CD](https://github.com/udibo/react_app/actions/workflows/main.yml/badge.svg)](https://github.com/udibo/react_app/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/udibo/react_app/branch/main/graph/badge.svg?token=G5XCR01X8E)](https://codecov.io/gh/udibo/react_app)
 [![license](https://img.shields.io/github/license/udibo/react_app)](https://github.com/udibo/react_app/blob/main/LICENSE)
@@ -31,13 +31,13 @@ Apps are created using [React Router](https://reactrouter.com),
 
 This module has 2 entry points.
 
-- [mod.tsx](https://deno.land/x/udibo_react_app@0.13.0/mod.tsx): For use in code
+- [mod.tsx](https://deno.land/x/udibo_react_app@0.14.0/mod.tsx): For use in code
   that will be used both on the server and in the browser.
-- [server.tsx](https://deno.land/x/udibo_react_app@0.13.0/server.tsx): For use
+- [server.tsx](https://deno.land/x/udibo_react_app@0.14.0/server.tsx): For use
   in code that will only be used on the server.
 
 You can look at the [examples](#examples) and
-[deno docs](https://deno.land/x/udibo_react_app@0.13.0) to learn more about
+[deno docs](https://deno.land/x/udibo_react_app@0.14.0) to learn more about
 usage.
 
 ### Examples

--- a/server.tsx
+++ b/server.tsx
@@ -566,7 +566,7 @@ export function generateRouter(
 
   const router = new Router();
   if (parent?.react && !react) {
-    router.use(async ({ response }, next) => {
+    router.use(async ({ request, response }, next) => {
       try {
         await next();
       } catch (cause) {
@@ -574,7 +574,10 @@ export function generateRouter(
         console.error("API error", error);
 
         response.status = error.status;
-        response.body = HttpError.json(error);
+        const extname = path.extname(request.url.pathname);
+        if (error.status !== 404 || extname === "") {
+          response.body = HttpError.json(error);
+        }
       }
     });
   }


### PR DESCRIPTION
If a request in an API route is not found, this change makes it so it will return an empty response for any request that had a file extension. It will still respond with JSON if there isn't a file extension for the route.